### PR TITLE
Keep sketch on top by default

### DIFF
--- a/clj/src/leiningen/new/quil/core.clj
+++ b/clj/src/leiningen/new/quil/core.clj
@@ -40,6 +40,7 @@
   ; update-state is called on each iteration before draw-state.
   :update update-state
   :draw draw-state
+  :features [:keep-on-top]
   ; This sketch uses functional-mode middleware.
   ; Check quil wiki for more info about middlewares and particularly
   ; fun-mode.


### PR DESCRIPTION
I think keep-on-top is the most convenient way to sketch. When coaching ClojureBridge this upcoming Friday, this'll make the students' lives easier.

(If you accept this pull request, I'd be grateful if clojars would be updated before Friday!)

**Positives:**
- Doesn't require moving windows around to accomodate sketch, for instant feedback.
- Mac users don't panic wondering why Quil doesn't work. (When the sketch is just hiding under other windows.)

**Negatives:**
- Can't think of any so far, except for really contrived ones.

**Tested** on MacOS X.
