### PR TITLE
Updated Copyright in README to current year

### DIFF
--- a/clj/src/leiningen/new/quil/README.md
+++ b/clj/src/leiningen/new/quil/README.md
@@ -12,7 +12,7 @@ REPL - run `(require '{{name}}.core)`.
 
 ## License
 
-Copyright © 2014 FIXME
+Copyright © 2016 FIXME
 
 Distributed under the Eclipse Public License either version 1.0 or (at
 your option) any later version.

--- a/cljs/src/leiningen/new/quil_cljs/README.md
+++ b/cljs/src/leiningen/new/quil_cljs/README.md
@@ -10,7 +10,7 @@ For interactive development run `lein cljsbuild auto` command. This command will
 
 ## License
 
-Copyright © 2015 FIXME
+Copyright © 2016 FIXME
 
 Distributed under the Eclipse Public License either version 1.0 or (at
 your option) any later version.


### PR DESCRIPTION
The copyright year was `2014` for Clojure, `2015` for ClojureScript. This PR fixes that.

Cheers