### PR TITLE
Fix java.lang.Exception raised when running test.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # quil-templates
 
-A Leiningen templates for [Quil](https://github.com/quil/quil).
+Leiningen templates for [Quil](https://github.com/quil/quil).
 
 There are 2 templates:
 
@@ -9,16 +9,16 @@ There are 2 templates:
 
 ## Usage
 
-To create a new quil project run following commands:
+To create a new quil project, run the following commands:
 
 `lein new quil my-project` - Quil on Clojure  
 `lein new quil-cljs my-project` - Quil on ClojureScript
 
-To run your Clojure project: 
+To run your Clojure project:
 
-`lein run -m my-project.core`
+`lein run`
 
-Make sure to replace `my-project` with a cool name for your project. 
+Make sure to replace `my-project` with a cool name for your project.
 
 ## License
 

--- a/clj/src/leiningen/new/quil/core.clj
+++ b/clj/src/leiningen/new/quil/core.clj
@@ -32,16 +32,17 @@
       ; Draw the circle.
       (q/ellipse x y 100 100))))
 
-(q/defsketch {{name}}
-  :title "You spin my circle right round"
-  :size [500 500]
-  ; setup function called only once, during sketch initialization.
-  :setup setup
-  ; update-state is called on each iteration before draw-state.
-  :update update-state
-  :draw draw-state
-  :features [:keep-on-top]
-  ; This sketch uses functional-mode middleware.
-  ; Check quil wiki for more info about middlewares and particularly
-  ; fun-mode.
-  :middleware [m/fun-mode])
+(defn -main [& args]
+  (q/defsketch {{name}}
+    :title "You spin my circle right round"
+    :size [500 500]
+    ; setup function called only once, during sketch initialization.
+    :setup setup
+    ; update-state is called on each iteration before draw-state.
+    :update update-state
+    :draw draw-state
+    :features [:keep-on-top]
+    ; This sketch uses functional-mode middleware.
+    ; Check quil wiki for more info about middlewares and particularly
+    ; fun-mode.
+    :middleware [m/fun-mode]))

--- a/clj/src/leiningen/new/quil/project.clj
+++ b/clj/src/leiningen/new/quil/project.clj
@@ -4,4 +4,5 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [quil "2.6.0"]])
+                 [quil "2.6.0"]]
+  :main {{name}}.core)

--- a/test_templates.sh
+++ b/test_templates.sh
@@ -18,7 +18,7 @@ cd $PROJECT
 echo
 echo "Running Clojure project."
 echo "------------------------"
-lein run -m $PROJECT.core
+lein run
 
 echo
 echo "Clojure project source."
@@ -59,5 +59,3 @@ rm -rf cljs/$PROJECT
 echo
 echo "Done"
 echo "----"
-
-


### PR DESCRIPTION
* A java.lang.Exception: "Cannot find anything to run..." was raised when issuing
  the `lein run` command. This was due to the missing `-main` function.
* Wrap `q/defsketch` in `(defn -main)`, and add `:main` key to
  project.clj.
* Update README. Because the `:main` key has been added to project.clj, it is no longer
  necessary to specify main namespace to `lein run` command.