### PR TITLE
Force recompilation for optimized build

### DIFF
--- a/cljs/src/leiningen/new/quil_cljs/README.md
+++ b/cljs/src/leiningen/new/quil_cljs/README.md
@@ -10,7 +10,7 @@ You can use this while developing your sketch. Whenever you save your source fil
 
 ## Publishing your sketch
 
-Before you publish your sketch, run `lein cljsbuild once optimized`. This will compile your code and run Google Closure Compiler with advanced optimizations. Take `resources/public/index.html` and `resources/public/js/main.js` and upload them to server of your choice.
+Before you publish your sketch, run `lein do clean, cljsbuild once optimized`. This will compile your code and run Google Closure Compiler with advanced optimizations. Take `resources/public/index.html` and `resources/public/js/main.js` and upload them to server of your choice.
 
 ## License
 

--- a/cljs/src/leiningen/new/quil_cljs/project.clj
+++ b/cljs/src/leiningen/new/quil_cljs/project.clj
@@ -11,6 +11,7 @@
             [lein-figwheel "0.5.14"]]
   :hooks [leiningen.cljsbuild]
 
+  :clean-targets ^{:protect false} ["resources/public/js"]
   :cljsbuild
   {:builds [; development build with figwheel hot swap
             {:id "development"


### PR DESCRIPTION
I found a bug that caused the compiler to skip the advanced build: When the source files have not changed and compiler output is present (which is exactly what happens when you're developing and try to build your latest version afterwards), `cljsbuild` does not re-compile (see also [here](https://github.com/emezeske/lein-cljsbuild/issues/414)). I made sure `lein clean` removes the compiled js files and updated the instructions in the README.