### PR TITLE
Document workarounds for quil-cljs template

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@ To run your Clojure project:
 
 Make sure to replace `my-project` with a cool name for your project.
 
+## Caveats
+
+The released `quil` template is using [quil v4.3.1323](https://github.com/quil/quil/releases/tag/v4.3.1323). However, the `quil-cljs` template was released under a Clojars group that is currently inaccessible, so the released version is still using the last quil release. It's possible to install and use the latest template by executing the following from a local checkout of this repository:
+
+```
+cd cljs
+lein install
+lein new quil-cljs my-project
+```
+
+Alternatively, the [quil/sketchbook-template](https://github.com/quil/sketchbook-template) contains a working CLJS template using the [deps-new](https://github.com/seancorfield/deps-new) template system.
+
 ## License
 
 Distributed under the Eclipse Public License either version 1.0 or (at


### PR DESCRIPTION
Add a caveat about how quil-cljs is not yet updated, how to update it locally, and a link to the new deps-new templates.